### PR TITLE
drive gpio output line on direction change

### DIFF
--- a/files/pinctrl-upboard.c
+++ b/files/pinctrl-upboard.c
@@ -1079,6 +1079,9 @@ static int upboard_gpio_direction_output(struct gpio_chip *gc,
 	struct upboard_pinctrl *pctrl = container_of(gc, struct upboard_pinctrl, chip); 
 	unsigned int pin = pctrl->rpi_mapping[offset];
 
+	// Set the output value before changing the mode.
+	upboard_gpio_set(gc, offset, value);
+
 	upboard_fpga_set_direction(pctrl->pctldev,NULL,pin,false);
 
 	if (gpio < 0)


### PR DESCRIPTION
The kernel function `gpiod_set_output` also gets a value and expects that the driver sets the gpio value while changing the gpio to output. Currently the driver does not do this resulting in an unexpected GPIO value. Adding a `upboard_gpio_set` ensures that we have the expected high/low value after the call.

See also the kernel documentation of the `gpiod_direction_output` method which eventually calls this `upboard_gpio_direction_output` method.